### PR TITLE
Make 12factor gem run only in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'twitter-bootstrap-rails', :git => 'git://github.com/seyhunak/twitter-bootst
 gem 'unicorn'
 gem 'faraday'
 gem 'figaro'
-gem 'rails_12factor'
 gem "omniauth-google-oauth2"
 
 group :development, :test do
@@ -41,3 +40,6 @@ group :development do
   gem 'web-console', '~> 2.0'
 end
 
+group :production do
+  gem 'rails_12factor'
+end


### PR DESCRIPTION
What you're running into is documented in the [Readme for the `rails_12factor` gem](https://github.com/heroku/rails_12factor#rails-4-logging). Heroku prefers logs to be output to `std_out`, which in most cases is the terminal. As soon as you install 12factor, all text that would normally go to the logs now gets output to your terminal. Since you installed 12factor on all environments, this includes the test environment. Since your test database is created and destroyed every time you rake, you saw the SQL output to your terminal when you ran `rake`. This is normal. This has happened every time your raked. It was just being put in your `log/test.log` file, and you probably never looked there.
